### PR TITLE
Log served file path in DEBUG level

### DIFF
--- a/src/cache_client.js
+++ b/src/cache_client.js
@@ -28,10 +28,11 @@ CacheClient.prototype.isCached = function (request) {
 
 CacheClient.prototype.fetch = function (request) {
   var self = this;
-  self.logger.debug(Color.blue('Serving'), self.path(request));
+  var filePath = self.path(request);
+  self.logger.debug(Color.blue('Serving'), filePath);
 
   return new Promise(function(resolve, reject) {
-    FileSystem.readFile(self.path(request), function (err, data) {
+    FileSystem.readFile(filePath, function (err, data) {
       if (err) {
         reject(err);
       } else {

--- a/src/cache_client.js
+++ b/src/cache_client.js
@@ -28,12 +28,13 @@ CacheClient.prototype.isCached = function (request) {
 
 CacheClient.prototype.fetch = function (request) {
   var self = this;
+  self.logger.debug(Color.blue('Serving'), self.path(request));
+
   return new Promise(function(resolve, reject) {
     FileSystem.readFile(self.path(request), function (err, data) {
       if (err) {
         reject(err);
       } else {
-        self.logger.debug(Color.blue('Serving'), self.path(request));
         resolve(Util.parseJSON(data));
       }
     });

--- a/src/cache_client.js
+++ b/src/cache_client.js
@@ -1,3 +1,4 @@
+var Color = require('./colorize');
 var FileSystem = require('fs');
 var path = require('path');
 var url = require('url')
@@ -32,6 +33,7 @@ CacheClient.prototype.fetch = function (request) {
       if (err) {
         reject(err);
       } else {
+        self.logger.debug(Color.blue('Serving'), self.path(request));
         resolve(Util.parseJSON(data));
       }
     });

--- a/src/colorize.js
+++ b/src/colorize.js
@@ -12,4 +12,8 @@ Colorize.yellow = function(text) {
   return "\033[1;33m" + text + "\033[0m";
 }
 
+Colorize.blue = function(text) {
+  return "\033[1;34m" + text + "\033[0m";
+}
+
 module.exports = Colorize


### PR DESCRIPTION
@blad 
This allows to log the name of the cached file on `DEBUG` level only.

We can change the displayed message, but this is pretty much what it'll log. 

```
DEBUG:    Serving    /path/to/file
```

![screen shot 2016-05-16 at 11 20 00 am](https://cloud.githubusercontent.com/assets/667672/15295827/2cfd587c-1b58-11e6-9c38-4a335cc000a5.png)
