### PR TITLE
Add none option to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ new Mockingjays().start({
   - ***Required***
 - **cacheHeader** - Headers that should be considered as part of the cache signature. By default all headers are ignored in the cache signature.
   - *Default: ''*
-- **logLevel** - The Level of Logging information that should be displayed to the console. Available options: `error`(least info, error only), `warn`, `info`, `debug` (most info).
+- **logLevel** - The Level of Logging information that should be displayed to the console.
+  - The available options are ranked from least info to most info:
+    * `none` - Nothing is logged.
+    * `error` - Only errors are logged.
+    * `warn` - Errors and warnings are logged.
+    * `info` - Errors, warnings, and info are logged.
+    * `debug` - Everything is logged.
   - *Default: info*
 - **port** - Port that the proxy server should bind to.
   - *Default: 9000*

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,7 @@
 import Colorize from './colorize';
 
 let Level = {
+  NONE: 0,
   ERROR: 1,
   WARN: 2,
   INFO: 3,
@@ -28,6 +29,9 @@ Logger.prototype.setLevel = function (logLevel) {
       break;
     case 'debug':
       this.level = Level.DEBUG;
+      break;
+    case 'none':
+      this.level = Level.NONE;
       break;
     default:
       console.warn('Unknown Log Level, Setting level to INFO');


### PR DESCRIPTION
## Changes
* Add `none` logging option
* Update README `logLevel` options

## Todo
* Feature tests.

## Rationale
I thought I wanted a `none` logging option, but then I realized I didn't. But figured it would be easy enough to add and could be useful to someone, so why not?

![](https://media.giphy.com/media/xT5LMLmLfsMkVNFe4E/giphy.gif)